### PR TITLE
Fix the crash when accessing the capsule ship info (mastery) with a character loaded

### DIFF
--- a/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.cs
+++ b/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.cs
@@ -103,7 +103,7 @@ namespace EVEMon.SkillPlanner
                     return;
 
                 m_masteryShip = value;
-                m_character = m_masteryShip.Character;
+                m_character = m_masteryShip?.Character;
                 UpdateTree();
             }
         }


### PR DESCRIPTION
if the user has the ship browser opened with a character loaded (displaying mastery tree), it'll cause a crash when trying to access the capsule information since no mastery information is available for the capsule. Also guards against eventual ship info with no mastery.