### PR TITLE
#36 Alpha Clone Training Times

### DIFF
--- a/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
@@ -153,11 +153,11 @@ namespace EVEMon.Common.Collections.Global
                 // Imports the character
                 SerializableCCPCharacter ccpCharacter = serialCharacter as SerializableCCPCharacter;
                 if (ccpCharacter != null)
-                    Items.Add(new CCPCharacter(id, ccpCharacter));
+                    this.Add(new CCPCharacter(id, ccpCharacter));
                 else
                 {
                     SerializableUriCharacter uriCharacter = serialCharacter as SerializableUriCharacter;
-                    Items.Add(new UriCharacter(id, uriCharacter));
+                    this.Add(new UriCharacter(id, uriCharacter));
                 }
             }
 
@@ -196,6 +196,17 @@ namespace EVEMon.Common.Collections.Global
             }
 
             return serial;
+        }
+
+        /// <summary>
+        /// Update character account statuses. Used after APIKeys list is updated
+        /// </summary>
+        internal void UpdateAccountStatuses()
+        {
+            foreach (Character character in Items)
+            {
+                character.UpdateAccountStatus();
+            }
         }
     }
 }

--- a/src/EVEMon.Common/EVEMon.Common.csproj
+++ b/src/EVEMon.Common/EVEMon.Common.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Enumerations\CharacterSaveFormat.cs" />
     <Compile Include="Extensions\ObjectExtensions.cs" />
     <Compile Include="Helpers\TaskHelper.cs" />
+    <Compile Include="Models\AccountStatus.cs" />
     <Compile Include="Serialization\SerializableAPIError.cs" />
     <Compile Include="CloudStorageServices\CloudStorageServiceAPIFile.cs" />
     <Compile Include="Serialization\SerializableAPIResult.cs" />

--- a/src/EVEMon.Common/EveMonClient.Events.cs
+++ b/src/EVEMon.Common/EveMonClient.Events.cs
@@ -417,6 +417,7 @@ namespace EVEMon.Common
                 return;
 
             Trace();
+            EveMonClient.Characters.UpdateAccountStatuses();
             Settings.Save();
             APIKeyCollectionChanged?.ThreadSafeInvoke(null, EventArgs.Empty);
         }
@@ -557,6 +558,8 @@ namespace EVEMon.Common
                 return;
 
             Trace(apiKey.ToString());
+            EveMonClient.Characters.UpdateAccountStatuses();
+            Settings.Save();
             AccountStatusUpdated?.ThreadSafeInvoke(null, EventArgs.Empty);
         }
 

--- a/src/EVEMon.Common/Models/APIKey.cs
+++ b/src/EVEMon.Common/Models/APIKey.cs
@@ -627,6 +627,9 @@ namespace EVEMon.Common.Models
 
             // Fires the event regarding the character list update
             EveMonClient.OnCharacterListUpdated(this);
+
+            // API collection changed, so we'll need to reprocess accounts.
+            EveMonClient.OnAPIKeyCollectionChanged();
         }
 
         /// <summary>

--- a/src/EVEMon.Common/Models/AccountStatus.cs
+++ b/src/EVEMon.Common/Models/AccountStatus.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EVEMon.Common.Models
+{
+    public class AccountStatus
+    {
+        public enum AccountStatusType { Unknown, Alpha, Omega };
+        
+        //TODO: Refactor, move constants
+        private const float trainingRateUnknown = 1.0f;
+        private const float trainingRateAlpha = 0.5f;
+        private const float trainingRateOmega = 1.0f;
+
+        //TODO: Refactor to create IAPIKey interface and use dependency injection here
+
+        /// <summary>
+        /// Creates an AccountStatus object with defined type
+        /// </summary>
+        /// <param name="statusType">Type (Alpha, Omega, Unknown).</param>
+        public AccountStatus(AccountStatusType statusType)
+        {
+            CurrentStatus = statusType;
+        }
+
+        /// <summary>
+        /// Creates an AccountStatus object from APIKey
+        /// </summary>
+        /// <param name="statusType">Type (Alpha, Omega, Unknown).</param>
+        public AccountStatus (APIKey apiKey)
+        {
+            if (apiKey == null || 
+                (apiKey != null &&  apiKey.Expiration < DateTime.UtcNow && apiKey.Expiration != DateTime.MinValue))
+            {
+                CurrentStatus = AccountStatusType.Unknown;
+            }
+            else
+            {
+                CurrentStatus = apiKey.AccountExpires > DateTime.UtcNow ?
+                   AccountStatusType.Omega :
+                   AccountStatusType.Alpha;
+            }
+        }
+        
+        /// <summary>
+        /// Spits out a friendly name for the Account Status
+        /// </summary>
+        public override string ToString()
+        {
+            string accountTypeName;
+
+            switch (CurrentStatus)
+            {
+                case AccountStatusType.Unknown:
+                    accountTypeName = "Unknown";
+                    break;
+                case AccountStatusType.Alpha:
+                    accountTypeName = "Alpha";
+                    break;
+                case AccountStatusType.Omega:
+                    accountTypeName = "Omega";
+                    break;
+                default:
+                    accountTypeName = "Unknown";
+                    break;
+            }
+            return accountTypeName;
+        }
+
+        public AccountStatusType CurrentStatus { get; private set; }
+
+        /// <summary>
+        /// Returns training rate adjusted for account status
+        /// </summary>
+        /// <returns>The skill point accrual rate (1.0 = base) modifier</returns>
+        public float TrainingRate
+        {
+            get
+            {
+                float rate = trainingRateUnknown;
+                switch (CurrentStatus)
+                {
+                    case AccountStatusType.Alpha:
+                        rate = trainingRateAlpha;
+                        break;
+                    case AccountStatusType.Omega:
+                        rate = trainingRateOmega;
+                        break;
+                    case AccountStatusType.Unknown:
+                        rate = trainingRateUnknown;
+                        break;
+                }
+                return rate;
+            }
+        }
+    }
+}

--- a/src/EVEMon.Common/Models/BaseCharacter.cs
+++ b/src/EVEMon.Common/Models/BaseCharacter.cs
@@ -36,7 +36,7 @@ namespace EVEMon.Common.Models
         /// <param name="skill">The skill.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException">skill</exception>
-        public float GetBaseSPPerHour(StaticSkill skill)
+        public virtual float GetBaseSPPerHour(StaticSkill skill)
         {
             skill.ThrowIfNull(nameof(skill));
 

--- a/src/EVEMon/ApiCredentialsManagement/ApiKeyUpdateOrAdditionWindow.cs
+++ b/src/EVEMon/ApiCredentialsManagement/ApiKeyUpdateOrAdditionWindow.cs
@@ -137,7 +137,7 @@ namespace EVEMon.ApiCredentialsManagement
                 return;
             }
 
-            // Display a warning if the cached timer hasn't expires yet
+            // Display a warning if the cached timer hasn't expired yet
             if (m_updateMode && m_apiKey.CachedUntil > DateTime.UtcNow)
             {
                 KeyPicture.Image = Resources.KeyWrong32;

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorHeader.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorHeader.cs
@@ -17,6 +17,7 @@ using EVEMon.Common.Factories;
 using EVEMon.Common.Interfaces;
 using EVEMon.Common.Models;
 using EVEMon.Common.Net;
+using static EVEMon.Common.Models.AccountStatus;
 
 namespace EVEMon.CharacterMonitoring
 {
@@ -264,13 +265,20 @@ namespace EVEMon.CharacterMonitoring
             {
                 APIKey apiKey = ccpCharacter.Identity.FindAPIKeyWithAccess(CCPAPICharacterMethods.AccountStatus);
 
-                AccountActivityLabel.Text = apiKey == null || apiKey.AccountExpires == DateTime.MinValue
-                                                ? "???"
-                                                : apiKey.AccountExpires > DateTime.UtcNow ? "Active" : "Expired";
+                AccountActivityLabel.Text = m_character.CharacterStatus.ToString();
 
-                AccountActivityLabel.ForeColor = apiKey == null || apiKey.AccountExpires == DateTime.MinValue
-                                                     ? SystemColors.ControlText
-                                                     : apiKey.AccountExpires > DateTime.UtcNow ? Color.DarkGreen : Color.Red;
+                switch (m_character.CharacterStatus.CurrentStatus)
+                {
+                    case AccountStatusType.Omega:
+                        AccountActivityLabel.ForeColor = Color.DarkGreen;
+                        break;
+                    case AccountStatusType.Alpha:
+                        AccountActivityLabel.ForeColor = SystemColors.ControlText;
+                        break;
+                    default:
+                        AccountActivityLabel.ForeColor = Color.Red;
+                        break;
+                }
 
                 PaidUntilLabel.Text = apiKey == null || apiKey.AccountExpires == DateTime.MinValue
                                           ? String.Empty


### PR DESCRIPTION
This is an initial shot at adding support for Alpha Clones.

Verified training times with Alpha, Omega, and NoAPI (unknown) characters.
Verified solo accounts.
Verified accounts with one character in training.
Did not verify MCT.

Creates class for Account Status and associates that to a character. If we go with this model, it should be helpful for filtering skill lists to make it easier to select only Alpha-compatible skills. Should be extensible for Beta (paid once) or other account/character types if/when they are added.

Will follow up via email to get code review and make any appropriate changes if this pull request is rejected.