### PR TITLE
Move time check from legacy NIST DAYTIME check to modern NTP-protocol

### DIFF
--- a/src/EVEMon.Common/Constants/NetworkConstants.Designer.cs
+++ b/src/EVEMon.Common/Constants/NetworkConstants.Designer.cs
@@ -1213,6 +1213,15 @@ namespace EVEMon.Common.Constants {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to pool.ntp.org.
+        /// </summary>
+        public static string GlobalNTPPool {
+            get {
+                return ResourceManager.GetString("GlobalNTPPool", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to https://ssl.google-analytics.com/collect.
         /// </summary>
         public static string GoogleAnalyticsUrl {

--- a/src/EVEMon.Common/Constants/NetworkConstants.resx
+++ b/src/EVEMon.Common/Constants/NetworkConstants.resx
@@ -567,4 +567,7 @@
   <data name="APICorporationBookmarks" xml:space="preserve">
     <value>/corp/Bookmarks.xml.aspx</value>
   </data>
+  <data name="GlobalNTPPool" xml:space="preserve">
+    <value>pool.ntp.org</value>
+  </data>
 </root>

--- a/src/EVEMon.Common/Helpers/TimeCheck.cs
+++ b/src/EVEMon.Common/Helpers/TimeCheck.cs
@@ -68,7 +68,6 @@ namespace EVEMon.Common.Helpers
                         var ntpData = new byte[48];
                         ntpData[0] = 0x1B; //LeapIndicator = 0 (no warning), VersionNum = 3 (IPv4 only), Mode = 3 (Client Mode)
 
-                        //var addresses = task.Dns.GetHostEntry(ntpServer).AddressList;
                         var ipEndPoint = new IPEndPoint(task.Result.First(), 123);
                         using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
                         {


### PR DESCRIPTION
This change eliminates the legacy NIST DAYTIME check for time skew and replaces it with an NTP-based check against the NTP Global Time Pool.. replacing the previous PR due to bad structure on my part.  Couple of advantages here:

1. Better support in aggressively firewalled environments, TCP 13 is frequently blocked, while NTP is a well known port that is often allowed out
2. Uses the global NTP pool (pool.ntp.org) which grabs a localized server with ~4,000 servers online today
3. Finer time resolution