### PR TITLE
Fix #77 skillpoints and SP/hour being wrong by guessing account status based on skill queue

### DIFF
--- a/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
@@ -197,16 +197,5 @@ namespace EVEMon.Common.Collections.Global
 
             return serial;
         }
-
-        /// <summary>
-        /// Update character account statuses. Used after APIKeys list is updated
-        /// </summary>
-        internal void UpdateAccountStatuses()
-        {
-            foreach (Character character in Items)
-            {
-                character.UpdateAccountStatus();
-            }
-        }
     }
 }

--- a/src/EVEMon.Common/EveMonClient.Events.cs
+++ b/src/EVEMon.Common/EveMonClient.Events.cs
@@ -639,6 +639,7 @@ namespace EVEMon.Common
                 return;
 
             Trace(character.Name);
+            character.UpdateAccountStatus();
             Settings.Save();
             CharacterSkillQueueUpdated?.ThreadSafeInvoke(null, new CharacterChangedEventArgs(character));
         }

--- a/src/EVEMon.Common/EveMonClient.Events.cs
+++ b/src/EVEMon.Common/EveMonClient.Events.cs
@@ -417,7 +417,6 @@ namespace EVEMon.Common
                 return;
 
             Trace();
-            EveMonClient.Characters.UpdateAccountStatuses();
             Settings.Save();
             APIKeyCollectionChanged?.ThreadSafeInvoke(null, EventArgs.Empty);
         }
@@ -558,7 +557,6 @@ namespace EVEMon.Common
                 return;
 
             Trace(apiKey.ToString());
-            EveMonClient.Characters.UpdateAccountStatuses();
             Settings.Save();
             AccountStatusUpdated?.ThreadSafeInvoke(null, EventArgs.Empty);
         }

--- a/src/EVEMon.Common/Models/AccountStatus.cs
+++ b/src/EVEMon.Common/Models/AccountStatus.cs
@@ -32,8 +32,7 @@ namespace EVEMon.Common.Models
         /// <param name="statusType">Type (Alpha, Omega, Unknown).</param>
         public AccountStatus (APIKey apiKey)
         {
-            if (apiKey == null || 
-                (apiKey != null &&  apiKey.Expiration < DateTime.UtcNow && apiKey.Expiration != DateTime.MinValue))
+            if (apiKey == null || (apiKey != null && apiKey.Expiration == DateTime.MinValue))
             {
                 CurrentStatus = AccountStatusType.Unknown;
             }

--- a/src/EVEMon.Common/Models/AccountStatus.cs
+++ b/src/EVEMon.Common/Models/AccountStatus.cs
@@ -27,24 +27,6 @@ namespace EVEMon.Common.Models
         }
 
         /// <summary>
-        /// Creates an AccountStatus object from APIKey
-        /// </summary>
-        /// <param name="statusType">Type (Alpha, Omega, Unknown).</param>
-        public AccountStatus (APIKey apiKey)
-        {
-            if (apiKey == null || (apiKey != null && apiKey.Expiration == DateTime.MinValue))
-            {
-                CurrentStatus = AccountStatusType.Unknown;
-            }
-            else
-            {
-                CurrentStatus = apiKey.AccountExpires > DateTime.UtcNow ?
-                   AccountStatusType.Omega :
-                   AccountStatusType.Alpha;
-            }
-        }
-        
-        /// <summary>
         /// Spits out a friendly name for the Account Status
         /// </summary>
         public override string ToString()

--- a/src/EVEMon.Common/Models/BaseCharacter.cs
+++ b/src/EVEMon.Common/Models/BaseCharacter.cs
@@ -41,6 +41,12 @@ namespace EVEMon.Common.Models
             return GetOmegaSPPerHour(skill);
         }
 
+        /// <summary>
+        /// Computes the SP per hour for the given skill, if the account status is Omega (subscribed)
+        /// </summary>
+        /// <param name="skill">The skill.</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException">skill</exception>
         public float GetOmegaSPPerHour(StaticSkill skill)
         {
             skill.ThrowIfNull(nameof(skill));

--- a/src/EVEMon.Common/Models/BaseCharacter.cs
+++ b/src/EVEMon.Common/Models/BaseCharacter.cs
@@ -38,6 +38,11 @@ namespace EVEMon.Common.Models
         /// <exception cref="System.ArgumentNullException">skill</exception>
         public virtual float GetBaseSPPerHour(StaticSkill skill)
         {
+            return GetOmegaSPPerHour(skill);
+        }
+
+        public float GetOmegaSPPerHour(StaticSkill skill)
+        {
             skill.ThrowIfNull(nameof(skill));
 
             if (skill.PrimaryAttribute == EveAttribute.None || skill.SecondaryAttribute == EveAttribute.None)

--- a/src/EVEMon.Common/Models/CCPCharacter.cs
+++ b/src/EVEMon.Common/Models/CCPCharacter.cs
@@ -297,7 +297,7 @@ namespace EVEMon.Common.Models
         /// <summary>
         /// Gets the skill currently in training, even when it is paused.
         /// </summary>
-        public override QueuedSkill CurrentlyTrainingSkill => SkillQueue.CurrentlyTraining;
+        public override QueuedSkill CurrentlyTrainingSkill => SkillQueue?.CurrentlyTraining;
 
         /// <summary>
         /// Gets a value indicating whether the character has insufficient balance to complete its buy orders.

--- a/src/EVEMon.Common/Models/Character.cs
+++ b/src/EVEMon.Common/Models/Character.cs
@@ -81,24 +81,28 @@ namespace EVEMon.Common.Models
             if (CurrentlyTrainingSkill != null && CurrentlyTrainingSkill.IsTraining)
             {
                 // Try to determine account status based on training time
-                var timeleft = (CurrentlyTrainingSkill.EndTime - CurrentlyTrainingSkill.StartTime).TotalHours;
-                if (timeleft > 0)
+                var hoursToTrain = (CurrentlyTrainingSkill.EndTime - CurrentlyTrainingSkill.StartTime).TotalHours;
+                if (hoursToTrain > 0)
                 {
-                    var spPerHour = CurrentlyTrainingSkill.Skill.GetLeftPointsRequiredToLevel(CurrentlyTrainingSkill.Level) / timeleft;
-                    if (spPerHour > 0)
+                    var spToTrain = (CurrentlyTrainingSkill.EndSP - CurrentlyTrainingSkill.StartSP);
+                    if (spToTrain > 0)
                     {
-                        var rate = (int)Math.Round(GetOmegaSPPerHour(CurrentlyTrainingSkill.Skill) / spPerHour, 0);
-                        switch (rate)
+                        var spPerHour = spToTrain / hoursToTrain;
+                        if (spPerHour > 0)
                         {
-                            case 1:
-                                statusType = AccountStatusType.Omega;
-                                break;
-                            case 2:
-                                statusType = AccountStatusType.Alpha;
-                                break;
-                            default:
-                                statusType = AccountStatusType.Unknown;
-                                break;
+                            var rate = (int)Math.Round(GetOmegaSPPerHour(CurrentlyTrainingSkill.Skill) / spPerHour, 0);
+                            switch (rate)
+                            {
+                                case 1:
+                                    statusType = AccountStatusType.Omega;
+                                    break;
+                                case 2:
+                                    statusType = AccountStatusType.Alpha;
+                                    break;
+                                default:
+                                    statusType = AccountStatusType.Unknown;
+                                    break;
+                            }
                         }
                     }
                 }

--- a/src/EVEMon.Common/Models/Character.cs
+++ b/src/EVEMon.Common/Models/Character.cs
@@ -78,6 +78,32 @@ namespace EVEMon.Common.Models
 
         public void UpdateAccountStatus(AccountStatusType statusType = AccountStatusType.Unknown)
         {
+            if (CurrentlyTrainingSkill != null && CurrentlyTrainingSkill.IsTraining)
+            {
+                // Try to determine account status based on training time
+                var timeleft = (CurrentlyTrainingSkill.EndTime - CurrentlyTrainingSkill.StartTime).TotalHours;
+                if (timeleft > 0)
+                {
+                    var spPerHour = CurrentlyTrainingSkill.Skill.GetLeftPointsRequiredToLevel(CurrentlyTrainingSkill.Level) / timeleft;
+                    if (spPerHour > 0)
+                    {
+                        var rate = (int)Math.Round(GetOmegaSPPerHour(CurrentlyTrainingSkill.Skill) / spPerHour, 0);
+                        switch (rate)
+                        {
+                            case 1:
+                                statusType = AccountStatusType.Omega;
+                                break;
+                            case 2:
+                                statusType = AccountStatusType.Alpha;
+                                break;
+                            default:
+                                statusType = AccountStatusType.Unknown;
+                                break;
+                        }
+                    }
+                }
+            }
+
             CharacterStatus = new AccountStatus(statusType);
         }
 

--- a/src/EVEMon.Common/Models/Character.cs
+++ b/src/EVEMon.Common/Models/Character.cs
@@ -76,17 +76,9 @@ namespace EVEMon.Common.Models
             UISettings = new CharacterUISettings();
         }
 
-        public void UpdateAccountStatus()
+        public void UpdateAccountStatus(AccountStatusType statusType = AccountStatusType.Unknown)
         {
-            APIKey apiKey = Identity.FindAPIKeyWithAccess(CCPAPICharacterMethods.AccountStatus);
-            if (apiKey != null)
-            {
-                CharacterStatus = new AccountStatus(apiKey);
-            }
-            else if (CharacterStatus == null)
-            {
-                CharacterStatus = new AccountStatus(AccountStatusType.Unknown);
-            }
+            CharacterStatus = new AccountStatus(statusType);
         }
 
         #endregion
@@ -443,7 +435,7 @@ namespace EVEMon.Common.Models
         /// <returns>Skill points earned per hour when training this skill</returns>
         public override float GetBaseSPPerHour(StaticSkill skill)
         {
-            return CharacterStatus.TrainingRate* base.GetBaseSPPerHour(skill);
+            return CharacterStatus.TrainingRate * base.GetBaseSPPerHour(skill);
         }
 
         #endregion

--- a/src/EVEMon.Common/Models/QueuedSkill.cs
+++ b/src/EVEMon.Common/Models/QueuedSkill.cs
@@ -32,6 +32,32 @@ namespace EVEMon.Common.Models
                 // Not paused, we should trust CCP
                 StartTime = serial.StartTime;
                 EndTime = serial.EndTime;
+
+                // Try to determine account status based on training time
+                var timeleft = (EndTime - StartTime).TotalHours;
+                if (timeleft > 0)
+                {
+                    var spPerHour = Skill.GetLeftPointsRequiredToLevel(Level) / timeleft;
+                    if (spPerHour > 0)
+                    {
+                        AccountStatus.AccountStatusType statusType;
+                        var rate = (int)Math.Round(((BaseCharacter)character).GetBaseSPPerHour(Skill) / spPerHour, 0);
+                        switch (rate)
+                        {
+                            case 1:
+                                statusType = AccountStatus.AccountStatusType.Omega;
+                                break;
+                            case 2:
+                                statusType = AccountStatus.AccountStatusType.Alpha;
+                                break;
+                            default:
+                                statusType = AccountStatus.AccountStatusType.Unknown;
+                                break;
+                        }
+
+                        character.UpdateAccountStatus(statusType);
+                    }
+                }
             }
             else
             {

--- a/src/EVEMon.Common/Models/QueuedSkill.cs
+++ b/src/EVEMon.Common/Models/QueuedSkill.cs
@@ -32,32 +32,6 @@ namespace EVEMon.Common.Models
                 // Not paused, we should trust CCP
                 StartTime = serial.StartTime;
                 EndTime = serial.EndTime;
-
-                // Try to determine account status based on training time
-                var timeleft = (EndTime - StartTime).TotalHours;
-                if (timeleft > 0)
-                {
-                    var spPerHour = Skill.GetLeftPointsRequiredToLevel(Level) / timeleft;
-                    if (spPerHour > 0)
-                    {
-                        AccountStatus.AccountStatusType statusType;
-                        var rate = (int)Math.Round(((BaseCharacter)character).GetBaseSPPerHour(Skill) / spPerHour, 0);
-                        switch (rate)
-                        {
-                            case 1:
-                                statusType = AccountStatus.AccountStatusType.Omega;
-                                break;
-                            case 2:
-                                statusType = AccountStatus.AccountStatusType.Alpha;
-                                break;
-                            default:
-                                statusType = AccountStatus.AccountStatusType.Unknown;
-                                break;
-                        }
-
-                        character.UpdateAccountStatus(statusType);
-                    }
-                }
             }
             else
             {


### PR DESCRIPTION
This fixed #77 which is caused by the account status defaulting to Alpha when the AccountStatus API doesn't provide an expiry date.
The number of trained skillpoints in a partially trained skill is calculated backwards based on the endtime and current skillpoints of the skill, but due to the training time incorrectly being interpreted as alpha based, even though it's omega.

The account status is now guessed based on the currently training skill, but it means that it won't be correct for Alpha characters that aren't training a skill.