### PR TITLE
Prevent hang in EVEmon.

### DIFF
--- a/src/EVEMon.LogitechG15/LcdDisplay.cs
+++ b/src/EVEMon.LogitechG15/LcdDisplay.cs
@@ -706,7 +706,11 @@ namespace EVEMon.LogitechG15
             int suffixIndex = 0;
             float newWidth;
 
-            do
+				if (width <= 0.0f) {
+					 return String.Empty;
+				}
+
+				do
             {
                 value /= 1000M;
                 suffixIndex++;


### PR DESCRIPTION
EVEMon hangs if it somehow gets a negative width value into this function.
How the negative got there would be the next logical question but I cannot practically replicate. :(